### PR TITLE
Updated Abstract Filtering To Match Website

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -74,7 +74,7 @@ export default class PaperNotesPlugin extends Plugin {
 		}
 
 		if (abstract) {
-			abstract = abstract.replace('Abstract: ', '');
+			abstract = abstract.replace('Abstract:', '');
 			abstract = abstract.replace(/\n/g, ' ');
 			abstract = abstract.replace('  ', ' ');
 			abstract = abstract.replace(/\t/g, '');


### PR DESCRIPTION
Greetings! I'm proposing an adjustment to the filtering of the paper's "abstract" selection.

Currently when importing `{{abstract}}` into a note it results in a value of `Abstract:{{abstract}}`

When you inspect the html, you'll notice it has no space after `Abstract:`. 

Snippet from website:
`<span class="descriptor">Abstract:</span>`

Thank you for putting this great project together!