### PR TITLE
A change to the `title` selector

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -98,7 +98,7 @@ export default class PaperNotesPlugin extends Plugin {
 		let note = this.settings.template;
 		
 		// Insert data into template
-		if (title) note = note.replace('{{title}}', title);
+		if (title) note = note.replace('{{arxiv_title}}', title);
 		if (authors) note = note.replace('{{authors}}', authors);
 		if (abstract) note = note.replace('{{abstract}}', abstract);
 


### PR DESCRIPTION
I propose a change to the `title` selector:
`{{title}}` conflicts with obsidian note [reserved words for templates](https://help.obsidian.md/Plugins/Templates#Template+variables).

Proposing a change of the selector to `{{arxiv_title}}`.